### PR TITLE
fix(grade-format): correccion en escala peru, cuando es redondeo de 1…

### DIFF
--- a/lib/grades/gradeFormat.ts
+++ b/lib/grades/gradeFormat.ts
@@ -10,7 +10,7 @@ Agrega puntos, comas, caracteres antes o despues de la nota.
 export const gradeFormat = (scale: ScaleAttributes, grade: number): string => {
   let round = `${gradeRound(scale, grade)}`
 
-  if (round.length === 1 && scale.append === '') {
+  if (round.length === 1 && scale.append === '' && scale.base !== 'Peru') {
     round = `${round}.0`
   }
 
@@ -18,5 +18,7 @@ export const gradeFormat = (scale: ScaleAttributes, grade: number): string => {
     scale.prepend,
     round.replace('.', scale.decimalSeparator),
     scale.append,
-  ].join('')
+  ]
+    .join('')
+    .trim()
 }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -129,6 +129,15 @@ export interface ScaleAttributes {
    * Caracter separador.
    */
   decimalSeparator: string
+
+  /**
+   * Base de la escala.
+   * - Chile
+   * - Peru
+   * - Colombia
+   * - Porcentaje
+   */
+  base: string
 }
 
 export type StatusReturn = {


### PR DESCRIPTION
… digito

El calculo agrega un .0 para el redondeo y luego lo quita con el replace con el separador de decimales
el caso es que en Perú la escala va de 2 a 0 pero sin separador de decimales, por lo tanto reemplaza el `.` por un caracter vacío dejando la ota 5 en 50